### PR TITLE
Optimization SendClientMessage - omp

### DIFF
--- a/zlang.inc
+++ b/zlang.inc
@@ -839,12 +839,20 @@ stock Lang_SendText(playerid, const var[], lang_args<>)
 	lang = Lang_GetPlayerLang(playerid);
 
 	Lang_GetText(lang, var, text);
+
+#if !defined _INC_open_mp
 	Lang_format(text, sizeof(text), text, lang_start<2>);
+#endif
+
 #if defined ENABLE_LANG_DYNAMIC_VARS
 	Lang_ProcessDynamicVars(lang, text);
 #endif
 
+#if !defined _INC_open_mp
 	return SendClientMessage(playerid, -1, text);
+#else
+	return Lang_SendClientMessage(playerid, text, lang_start<2>);
+#endif
 }
 
 stock Lang_SendTextToAll(const var[], lang_args<>)
@@ -1355,3 +1363,77 @@ stock Lang_format(out[], size, const fmat[], lang_:STATIC_ARGS)
 
 	return 0;
 }
+
+// open.mp
+#if defined _INC_open_mp
+
+// Function SendClientMessage
+static stock Lang_SendClientMessage(playerid, const fmat[], lang_:STATIC_ARGS)
+{
+	static
+		YSI_g_sHeap,
+		YSI_g_sStack,
+		YSI_g_sArgCount,
+		YSI_g_sArgs[5];
+
+	//P:C(if (_:STATIC_ARGS < 1) P:W("No static args found, please add a dummy local"););
+	// Get the number of parameters.
+	#emit LOAD.S.alt   STATIC_ARGS
+	#emit DEC.alt      // 2 - n
+	#emit SHL.C.alt    2
+	// "alt" now contains the number of static arguments in bytes - 4.
+
+	// Get the previous parameter count.
+	#emit LOAD.S.pri   0
+	#emit ADD.C        8
+	#emit LOAD.I
+	#emit SUB
+	#emit ADD.C        8
+	#emit STOR.pri     YSI_g_sArgCount // "format"s parameter count.
+
+	// Get the address of the arguments we are replacing.
+	#emit LOAD.S.pri   0
+	#emit ADD
+
+	// Copy them to our temporary buffer.
+	#emit CONST.alt    YSI_g_sArgs
+	#emit MOVS         16 // (n + 1) * 4
+
+	// Go to the new "top" of the stack.
+	#emit STACK        0
+	#emit STOR.alt     YSI_g_sStack    // Store it.
+	#emit ADD.C        16 // (n + 1) * 4
+	#emit SCTRL        4
+
+	// "frm" is still valid.
+	#emit PUSH.S       fmat
+	#emit PUSH.C       0xFFFFFFFF
+	#emit PUSH.S       playerid
+	#emit PUSH         YSI_g_sArgCount // Push the parameter count.
+
+	// Modify the heap to hold "locals".
+	#emit HEAP         0
+	#emit STOR.alt     YSI_g_sHeap
+	#emit LCTRL        4
+	#emit SCTRL        2
+
+	// Call the function.
+	#emit SYSREQ.C     SendClientMessage
+	#emit STOR.pri     YSI_g_sArgCount
+
+	// Copy the data back.
+	#emit LOAD.pri     YSI_g_sHeap
+	#emit SCTRL        2
+	#emit STACK        0
+	#emit CONST.pri    YSI_g_sArgs
+	#emit MOVS         16
+	#emit LOAD.pri     YSI_g_sStack
+	#emit SCTRL        4
+
+	#emit LOAD.pri     YSI_g_sArgCount
+	#emit RETN
+
+	return 0;
+}
+
+#endif


### PR DESCRIPTION
Вообщем да, менять функции на макросы слишком жёстко: https://github.com/Open-GTO/zlang/pull/11
~Но в целом, лично я буду использовать метод с макросами, т.к. он шустрее всех решений.~

Сейчас я просто решил вопрос с форматированием, всё таки получилось и это добавляет немного скорости, т.к. пропускает форматирование текста и сразу вызывается `SendClientMessage` в `Lang_SendClientMessage`, вместо использования `Lang_format`.

Немного из тестов на omp сервере, вызов функции на 1млн итераций в `OnGameModeInit()`:
`Lang_SendText(0, "MESSAGE_MIN_MAX_WEAPON_AMMO", 10, 22);`
`MESSAGE_MIN_MAX_WEAPON_AMMO = "[Ошибка] {FFFFFF}Запрещается меньше %i или больше %i патронов."`

С использованием `Lang_SendClientMessage`: 1463 ms, 1429 ms, 1435 ms
С использованием `Lang_format`: 1789 ms, 1765 ms, 1703 ms
Ну и с использованием `макросов`: 1284 ms, 1265 ms, 1258 ms

И что не мало важно, если хоть где-то (во внешних скриптах) используется перехват `ALS` `SendClientMessage`, то он необязательно должен быть правильный, т.е. с новыми неопределёнными аргументами из omp, на `Lang_SendText` никак не повлияет, пример:

```Pawn
stock Test_SendClientMessage(playerid, colour, const format[], OPEN_MP_TAGS:...)
{
	return SendClientMessage(playerid, colour, format);
}

#if defined _ALS_SendClientMessage
	#undef SendClientMessage
#else
	#define _ALS_SendClientMessage
#endif
#define SendClientMessage Test_SendClientMessage
```

Получается очень универсально и не ломает совместимость. Если вдруг понравится, могу сделать для остальных функций тоже самое.