### PR TITLE
Add SVar's (optional) for omp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 GVar per player lang system
 
 # Requirements
-- [GVar plugin](https://github.com/samp-incognito/samp-gvar-plugin)
+- [GVar plugin](https://github.com/samp-incognito/samp-gvar-plugin) - when using opem.mp of course, it is possible not to use the GVar plugin, just set `ZLANG_DISABLE_GVAR` before connecting the script.
 - [foreach](https://github.com/Open-GTO/foreach) - not necessary but recommended
 
 # Libraries compatible with zlang

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 GVar per player lang system
 
 # Requirements
-- [GVar plugin](https://github.com/samp-incognito/samp-gvar-plugin) - when using opem.mp of course, it is possible not to use the GVar plugin, just set `ZLANG_DISABLE_GVAR` before connecting the script.
+- [GVar plugin](https://github.com/samp-incognito/samp-gvar-plugin) - when using opem.mp of course, it is possible not to use the GVar plugin, just set `LANG_USE_SVAR` before connecting the script.
 - [foreach](https://github.com/Open-GTO/foreach) - not necessary but recommended
 
 # Libraries compatible with zlang

--- a/zlang.inc
+++ b/zlang.inc
@@ -13,16 +13,8 @@
 #endif
 
 // Method of using variables
-#if !defined LANG_USE_SVAR
-	// GVar
-	#if !defined LANG_USE_GVAR
-		#define LANG_USE_GVAR
-	#endif
-#else
-	// GVar
-	#if defined LANG_USE_GVAR
-		#undef LANG_USE_GVAR
-	#endif
+#if !defined LANG_USE_SVAR && !defined LANG_USE_GVAR
+  #define LANG_USE_GVAR
 #endif
 
 // Include GVar

--- a/zlang.inc
+++ b/zlang.inc
@@ -47,7 +47,7 @@
 #endif
 
 #if !defined MAX_LANG_VAR_STRING
-	#define MAX_LANG_VAR_STRING (144)
+	#define MAX_LANG_VAR_STRING (MAX_LANGS + 144)
 #endif
 
 #if !defined MAX_LANG_VALUE_STRING
@@ -84,12 +84,6 @@
 
 #if !defined MAX_LANG_FILENAME
 	#define MAX_LANG_FILENAME (256)
-#endif
-
-#if defined ZLANG_DISABLE_GVAR
-	#if !defined MAX_LANG_SVAR_NAME
-		#define MAX_LANG_SVAR_NAME (MAX_LANGS + MAX_LANG_VAR_STRING)
-	#endif
 #endif
 
 #define INVALID_LANG_ID (Lang:-1)
@@ -290,11 +284,7 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 		idx,
 		symbol,
 		length,
-	#if !defined ZLANG_DISABLE_GVAR
-		strings_with_vars;
-	#else
-		bool:isProcessSvar = false;
-	#endif
+		bool:isProcessVar = false;
 
 	while (fread(flang, string, sizeof(string))) {
 		switch (string[0]) {
@@ -372,8 +362,8 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 						length++;
 						symbol = string[i + length + 1];
 					} while (   '0' <= symbol <= '9'
-					         || 'A' <= symbol <= 'F'
-					         || 'a' <= symbol <= 'f');
+							 || 'A' <= symbol <= 'F'
+							 || 'a' <= symbol <= 'f');
 
 					for (idx = 1; idx <= length; idx++) {
 						symbol = string[i + idx];
@@ -397,20 +387,7 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 					strdel(string, i + 1, i + length + 1);
 				}
 				case 'v': {
-				#if !defined ZLANG_DISABLE_GVAR
-					new
-						exist,
-						temp[MAX_LANG_VAR_STRING + 1];
-
-					exist = GetGVarString("zlang_vars_name", temp, .id = strings_with_vars - 1);
-
-					if (!exist || strcmp(varname, temp, true)) {
-						SetGVarString("zlang_vars_name", varname, strings_with_vars);
-						strings_with_vars++;
-					}
-				#else
-					isProcessSvar = true;
-				#endif
+					isProcessVar = true;
 				}
 			}
 		}
@@ -418,18 +395,11 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 		string[i] = '\0';
 		_Lang_SetText(lang, varname, string[sep_epos]);
 
-	#if defined ZLANG_DISABLE_GVAR
-		if (isProcessSvar) {
-			isProcessSvar = false;
-			_Lang_ProcessSVars(lang, varname);
+		if (isProcessVar) {
+			isProcessVar = false;
+			_Lang_ProcessVars(lang, varname);
 		}
-	#endif
 	}
-
-#if !defined ZLANG_DISABLE_GVAR
-	// vars processing
-	_Lang_ProcessGVars(lang, strings_with_vars);
-#endif
 
 	fclose(flang);
 	return fid;
@@ -687,12 +657,7 @@ stock Lang_SetText(Lang:lang, const var[], const text[])
 	new res = _Lang_SetText(lang, var_temp, text);
 
 	if (strfind(text, "\\v(", true) != -1) {
-	#if !defined ZLANG_DISABLE_GVAR
-		SetGVarString("zlang_vars_name", var, 0);
-		_Lang_ProcessGVars(lang, 1);
-	#else
-		_Lang_ProcessSVars(lang, var_temp);
-	#endif
+		_Lang_ProcessVars(lang, var_temp);
 	}
 
 	return res;
@@ -1075,17 +1040,62 @@ stock Lang_UpdatePlayer3DTextLabel(playerid, PlayerText3D:id, color, const var[]
 }
 
 /*
-	Private functions
+	Vars
 */
 
-#if defined ZLANG_DISABLE_GVAR
-
-static stock _Lang_GetSVar(Lang:lang, const var[], svarname[], const size = sizeof(svarname))
+static stock _Lang_SetVarString(Lang:lang, const var[], const text[])
 {
-	format(svarname, size, "%d%s", _:lang, var);
+#if !defined ZLANG_DISABLE_GVAR
+	return SetGVarString(var, text, LANG_VAR_OFFSET + _:lang);
+#else
+	#pragma unused lang
+	return SetSVarString(var, text);
+#endif
 }
 
+static stock _Lang_GetVarString(Lang:lang, const var[], text[], const size = sizeof(text))
+{
+#if !defined ZLANG_DISABLE_GVAR
+	return GetGVarString(var, text, size, LANG_VAR_OFFSET + _:lang);
+#else
+	#pragma unused lang
+	return GetSVarString(var, text, size);
 #endif
+}
+
+static stock _Lang_DeleteVar(Lang:lang, const var[])
+{
+#if !defined ZLANG_DISABLE_GVAR
+	return DeleteGVar(var, LANG_VAR_OFFSET + _:lang);
+#else
+	#pragma unused lang
+	return DeleteSVar(var);
+#endif
+}
+
+static stock _Lang_GetVarType(Lang:lang, const var[])
+{
+#if !defined ZLANG_DISABLE_GVAR
+	return GetGVarType(var, LANG_VAR_OFFSET + _:lang) != GLOBAL_VARTYPE_NONE;
+#else
+	#pragma unused lang
+	return GetSVarType(var) != SERVER_VARTYPE_NONE;
+#endif
+}
+
+static stock _Lang_ConvertVar(Lang:lang, const var[], varname[], const size = sizeof(varname))
+{
+#if !defined ZLANG_DISABLE_GVAR
+	#pragma unused lang
+	strcat((varname[0] = EOS, varname), var, size);
+#else
+	format(varname, size, "%d%s", _:lang, var);
+#endif
+}
+
+/*
+	Private functions
+*/
 
 static stock _Lang_FindFile(Lang:lang, const filename[])
 {
@@ -1119,15 +1129,11 @@ static stock _Lang_GetFreeFileSlot(Lang:lang)
 
 static stock _Lang_SetText(Lang:lang, const var[], const text[])
 {
-#if !defined ZLANG_DISABLE_GVAR
-	return SetGVarString(var, text, LANG_VAR_OFFSET + _:lang);
-#else
 	static
-		svarname[MAX_LANG_SVAR_NAME + 1];
+		varname[MAX_LANG_VAR_STRING + 1];
 
-	_Lang_GetSVar(lang, var, svarname);
-	return SetSVarString(svarname, text);
-#endif
+	_Lang_ConvertVar(lang, var, varname);
+	return _Lang_SetVarString(lang, varname, text);
 }
 
 static stock _Lang_GetText(Lang:lang, const var[], text[], const size = sizeof(text))
@@ -1136,31 +1142,18 @@ static stock _Lang_GetText(Lang:lang, const var[], text[], const size = sizeof(t
 		success,
 		i,
 		text_multi[MAX_LANG_VALUE_STRING],
-	#if !defined ZLANG_DISABLE_GVAR
+		var_name[MAX_LANG_VAR_STRING + 1],
 		var_multi[MAX_LANG_VAR_STRING + 6];
-	#else
-		var_multi[MAX_LANG_SVAR_NAME + 6],
-		svarname[MAX_LANG_SVAR_NAME + 1];
-	#endif
 
-#if !defined ZLANG_DISABLE_GVAR
-	success = GetGVarString(var, text, size, LANG_VAR_OFFSET + _:lang);
-#else
-	_Lang_GetSVar(lang, var, svarname);
-	success = GetSVarString(svarname, text, size);
-#endif
+	_Lang_ConvertVar(lang, var, var_name);
+	success = _Lang_GetVarString(lang, var_name, text, size);
 
 	if (!success) {
 		i = 0;
 
 		do {
-		#if !defined ZLANG_DISABLE_GVAR
-			format(var_multi, sizeof(var_multi), "%s_%d", var, i);
-			success = GetGVarString(var_multi, text_multi, sizeof(text_multi), LANG_VAR_OFFSET + _:lang);
-		#else
-			format(var_multi, sizeof(var_multi), "%s_%d", svarname, i);
-			success = GetSVarString(var_multi, text_multi, sizeof(text_multi));
-		#endif
+			format(var_multi, sizeof(var_multi), "%s_%d", var_name, i);
+			success = _Lang_GetVarString(lang, var_multi, text_multi, sizeof(text_multi));
 
 			if (success) {
 				if (i == 0) {
@@ -1181,95 +1174,29 @@ static stock _Lang_GetText(Lang:lang, const var[], text[], const size = sizeof(t
 
 static stock _Lang_RemoveText(Lang:lang, const var[])
 {
-#if !defined ZLANG_DISABLE_GVAR
-	return DeleteGVar(var, LANG_VAR_OFFSET + _:lang);
-#else
 	static
-		svarname[MAX_LANG_SVAR_NAME + 1];
+		varname[MAX_LANG_VAR_STRING + 1];
 
-	_Lang_GetSVar(lang, var, svarname);
-	return DeleteSVar(svarname);
-#endif
+	_Lang_ConvertVar(lang, var, varname);
+	return _Lang_DeleteVar(lang, varname);
 }
 
 static stock _Lang_IsTextExists(Lang:lang, const var[])
 {
-#if !defined ZLANG_DISABLE_GVAR
-	return GetGVarType(var, LANG_VAR_OFFSET + _:lang) != GLOBAL_VARTYPE_NONE;
-#else
 	static
-		svarname[MAX_LANG_SVAR_NAME + 1];
+		varname[MAX_LANG_VAR_STRING + 1];
 
-	_Lang_GetSVar(lang, var, svarname);
-	return GetSVarType(svarname) != SERVER_VARTYPE_NONE;
-#endif
+	_Lang_ConvertVar(lang, var, varname);
+	return _Lang_GetVarType(lang, varname);
 }
 
-#if !defined ZLANG_DISABLE_GVAR
-
-static stock _Lang_ProcessGVars(Lang:lang, strings_with_vars)
+static stock _Lang_ProcessVars(Lang:lang, const var[])
 {
 	new
-		i,
 		spos,
 		epos,
-		varname[MAX_LANG_VAR_STRING + 1],
 		varvalue[MAX_LANG_VALUE_STRING + 1],
-		bool:next_iteration,
 		vartmp[MAX_LANG_VAR_STRING + 1],
-		valtmp[MAX_LANG_VALUE_STRING + 1];
-
-	do {
-		next_iteration = false;
-
-		for (i = 0; i < strings_with_vars; i++) {
-			if (!GetGVarString("zlang_vars_name", varname, .id = i)) {
-				continue;
-			}
-
-			_Lang_GetText(lang, varname, varvalue);
-
-			while ((spos = strfind(varvalue, "\\v(", true, spos)) != -1) {
-				next_iteration = true;
-
-				epos = strfind(varvalue, ")", true, spos);
-				if (epos == -1) {
-					next_iteration = false;
-					printf("Error: error with using language variables, example of usage: \\v(VARIABLE)");
-					break;
-				}
-
-				strmid(vartmp, varvalue, spos + 3, epos);
-
-				if (vartmp[0] == '%' && vartmp[1] == 's') {
-					spos += 1;
-					_Lang_SetText(lang, varname, varvalue);
-
-					continue;
-				}
-
-				_Lang_GetText(lang, vartmp, valtmp);
-
-				strdel(varvalue, spos, epos + 1);
-				format(varvalue, sizeof(varvalue), "%.*s%s%s", spos, varvalue, valtmp, varvalue[spos]);
-
-				_Lang_SetText(lang, varname, varvalue);
-			}
-
-			DeleteGVar("zlang_vars_name", i);
-		}
-	} while (next_iteration);
-}
-
-#else
-
-static stock _Lang_ProcessSVars(Lang:lang, const var[])
-{
-	new
-		spos,
-		epos,
-		varvalue[MAX_LANG_VALUE_STRING + 1],
-		vartmp[MAX_LANG_SVAR_NAME + 1],
 		valtmp[MAX_LANG_VALUE_STRING + 1];
 
 	_Lang_GetText(lang, var, varvalue);
@@ -1297,8 +1224,6 @@ static stock _Lang_ProcessSVars(Lang:lang, const var[])
 		_Lang_SetText(lang, var, varvalue);
 	}
 }
-
-#endif
 
 stock Lang_ProcessDynamicVars(Lang:lang, text[], const size = sizeof(text))
 {

--- a/zlang.inc
+++ b/zlang.inc
@@ -421,7 +421,7 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 
 		if (is_process_var) {
 			is_process_var = false;
-			_Lang_ProcessVars(lang, varname);
+			_Lang_ProcessVar(lang, varname);
 		}
 	}
 
@@ -681,7 +681,7 @@ stock Lang_SetText(Lang:lang, const var[], const text[])
 	new res = _Lang_SetText(lang, var_temp, text);
 
 	if (strfind(text, "\\v(", true) != -1) {
-		_Lang_ProcessVars(lang, var_temp);
+		_Lang_ProcessVar(lang, var_temp);
 	}
 
 	return res;
@@ -1218,7 +1218,7 @@ static stock _Lang_IsTextExists(Lang:lang, const var[])
 #endif
 }
 
-static stock _Lang_ProcessVars(Lang:lang, const var[])
+static stock _Lang_ProcessVar(Lang:lang, const var[])
 {
 	new
 		spos,

--- a/zlang.inc
+++ b/zlang.inc
@@ -47,7 +47,7 @@
 #endif
 
 #if !defined MAX_LANG_VAR_STRING
-	#define MAX_LANG_VAR_STRING (MAX_LANGS + 144)
+	#define MAX_LANG_VAR_STRING (6 + 144)
 #endif
 
 #if !defined MAX_LANG_VALUE_STRING

--- a/zlang.inc
+++ b/zlang.inc
@@ -2,15 +2,31 @@
 
 	About: GVar per player lang system
 	Author: ziggi
+	Description: by default, the GVar plugin is used,
+	but when using opem.mp of course, it can be excluded by adding `LANG_USE_SVAR`
 
 */
 
+// Checking for sa-mp included
 #if !defined _samp_included
 	#error Please include a_samp or a_npc before zlang
 #endif
 
-// GVar
-#if !defined ZLANG_DISABLE_GVAR
+// Method of using variables
+#if !defined LANG_USE_SVAR
+	// GVar
+	#if !defined LANG_USE_GVAR
+		#define LANG_USE_GVAR
+	#endif
+#else
+	// GVar
+	#if defined LANG_USE_GVAR
+		#undef LANG_USE_GVAR
+	#endif
+#endif
+
+// Include GVar
+#if defined LANG_USE_GVAR
 	#if !defined SetGVarString
 		#tryinclude "gvar"
 	#endif
@@ -24,6 +40,7 @@
 	#endif
 #endif
 
+// zlang
 #if defined _zlang_included
 	#endinput
 #endif
@@ -47,7 +64,7 @@
 #endif
 
 #if !defined MAX_LANG_VAR_STRING
-	#define MAX_LANG_VAR_STRING (6 + 144)
+	#define MAX_LANG_VAR_STRING (144)
 #endif
 
 #if !defined MAX_LANG_VALUE_STRING
@@ -84,6 +101,17 @@
 
 #if !defined MAX_LANG_FILENAME
 	#define MAX_LANG_FILENAME (256)
+#endif
+
+// SVar
+#if defined LANG_USE_SVAR
+	#if !defined MAX_LANG_PREFIX_SVAR_STRING
+		#define MAX_LANG_PREFIX_SVAR_STRING (7 + MAX_LANG_VAR_STRING)
+	#endif
+
+	#if !defined LANG_SVAR_VARNAME_MASK
+		#define LANG_SVAR_VARNAME_MASK "lng%d_%s"
+	#endif
 #endif
 
 #define INVALID_LANG_ID (Lang:-1)
@@ -284,7 +312,7 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 		idx,
 		symbol,
 		length,
-		bool:isProcessVar = false;
+		bool:is_process_var = false;
 
 	while (fread(flang, string, sizeof(string))) {
 		switch (string[0]) {
@@ -362,8 +390,8 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 						length++;
 						symbol = string[i + length + 1];
 					} while (   '0' <= symbol <= '9'
-							 || 'A' <= symbol <= 'F'
-							 || 'a' <= symbol <= 'f');
+					         || 'A' <= symbol <= 'F'
+					         || 'a' <= symbol <= 'f');
 
 					for (idx = 1; idx <= length; idx++) {
 						symbol = string[i + idx];
@@ -387,7 +415,7 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 					strdel(string, i + 1, i + length + 1);
 				}
 				case 'v': {
-					isProcessVar = true;
+					is_process_var = true;
 				}
 			}
 		}
@@ -395,8 +423,8 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 		string[i] = '\0';
 		_Lang_SetText(lang, varname, string[sep_epos]);
 
-		if (isProcessVar) {
-			isProcessVar = false;
+		if (is_process_var) {
+			is_process_var = false;
 			_Lang_ProcessVars(lang, varname);
 		}
 	}
@@ -1045,51 +1073,73 @@ stock Lang_UpdatePlayer3DTextLabel(playerid, PlayerText3D:id, color, const var[]
 
 static stock _Lang_SetVarString(Lang:lang, const var[], const text[])
 {
-#if !defined ZLANG_DISABLE_GVAR
+#if defined LANG_USE_GVAR
 	return SetGVarString(var, text, LANG_VAR_OFFSET + _:lang);
-#else
-	#pragma unused lang
-	return SetSVarString(var, text);
+#endif
+
+#if defined LANG_USE_SVAR
+	static
+		varname[MAX_LANG_PREFIX_SVAR_STRING + 1];
+
+	_Lang_ConvertVar(lang, var, varname);
+	return SetSVarString(varname, text);
 #endif
 }
 
 static stock _Lang_GetVarString(Lang:lang, const var[], text[], const size = sizeof(text))
 {
-#if !defined ZLANG_DISABLE_GVAR
+#if defined LANG_USE_GVAR
 	return GetGVarString(var, text, size, LANG_VAR_OFFSET + _:lang);
-#else
-	#pragma unused lang
-	return GetSVarString(var, text, size);
+#endif
+
+#if defined LANG_USE_SVAR
+	static
+		varname[MAX_LANG_PREFIX_SVAR_STRING + 1];
+
+	_Lang_ConvertVar(lang, var, varname);
+	return GetSVarString(varname, text, size);
 #endif
 }
 
 static stock _Lang_DeleteVar(Lang:lang, const var[])
 {
-#if !defined ZLANG_DISABLE_GVAR
+#if defined LANG_USE_GVAR
 	return DeleteGVar(var, LANG_VAR_OFFSET + _:lang);
-#else
-	#pragma unused lang
-	return DeleteSVar(var);
+#endif
+
+#if defined LANG_USE_SVAR
+	static
+		varname[MAX_LANG_PREFIX_SVAR_STRING + 1];
+
+	_Lang_ConvertVar(lang, var, varname);
+	return DeleteSVar(varname);
 #endif
 }
 
 static stock _Lang_GetVarType(Lang:lang, const var[])
 {
-#if !defined ZLANG_DISABLE_GVAR
+#if defined LANG_USE_GVAR
 	return GetGVarType(var, LANG_VAR_OFFSET + _:lang) != GLOBAL_VARTYPE_NONE;
-#else
-	#pragma unused lang
-	return GetSVarType(var) != SERVER_VARTYPE_NONE;
+#endif
+
+#if defined LANG_USE_SVAR
+	static
+		varname[MAX_LANG_PREFIX_SVAR_STRING + 1];
+
+	_Lang_ConvertVar(lang, var, varname);
+	return GetSVarType(varname) != SERVER_VARTYPE_NONE;
 #endif
 }
 
 static stock _Lang_ConvertVar(Lang:lang, const var[], varname[], const size = sizeof(varname))
 {
-#if !defined ZLANG_DISABLE_GVAR
+#if defined LANG_USE_GVAR
 	#pragma unused lang
-	strcat((varname[0] = EOS, varname), var, size);
-#else
-	format(varname, size, "%d%s", _:lang, var);
+	_Lang_strcpy(varname, var, size);
+#endif
+
+#if defined LANG_USE_SVAR
+	format(varname, size, LANG_SVAR_VARNAME_MASK, _:lang, var);
 #endif
 }
 
@@ -1129,11 +1179,7 @@ static stock _Lang_GetFreeFileSlot(Lang:lang)
 
 static stock _Lang_SetText(Lang:lang, const var[], const text[])
 {
-	static
-		varname[MAX_LANG_VAR_STRING + 1];
-
-	_Lang_ConvertVar(lang, var, varname);
-	return _Lang_SetVarString(lang, varname, text);
+	return _Lang_SetVarString(lang, var, text);
 }
 
 static stock _Lang_GetText(Lang:lang, const var[], text[], const size = sizeof(text))
@@ -1142,17 +1188,15 @@ static stock _Lang_GetText(Lang:lang, const var[], text[], const size = sizeof(t
 		success,
 		i,
 		text_multi[MAX_LANG_VALUE_STRING],
-		var_name[MAX_LANG_VAR_STRING + 1],
 		var_multi[MAX_LANG_VAR_STRING + 6];
 
-	_Lang_ConvertVar(lang, var, var_name);
-	success = _Lang_GetVarString(lang, var_name, text, size);
+	success = _Lang_GetVarString(lang, var, text, size);
 
 	if (!success) {
 		i = 0;
 
 		do {
-			format(var_multi, sizeof(var_multi), "%s_%d", var_name, i);
+			format(var_multi, sizeof(var_multi), "%s_%d", var, i);
 			success = _Lang_GetVarString(lang, var_multi, text_multi, sizeof(text_multi));
 
 			if (success) {
@@ -1174,20 +1218,12 @@ static stock _Lang_GetText(Lang:lang, const var[], text[], const size = sizeof(t
 
 static stock _Lang_RemoveText(Lang:lang, const var[])
 {
-	static
-		varname[MAX_LANG_VAR_STRING + 1];
-
-	_Lang_ConvertVar(lang, var, varname);
-	return _Lang_DeleteVar(lang, varname);
+	return _Lang_DeleteVar(lang, var);
 }
 
 static stock _Lang_IsTextExists(Lang:lang, const var[])
 {
-	static
-		varname[MAX_LANG_VAR_STRING + 1];
-
-	_Lang_ConvertVar(lang, var, varname);
-	return _Lang_GetVarType(lang, varname);
+	return _Lang_GetVarType(lang, var);
 }
 
 static stock _Lang_ProcessVars(Lang:lang, const var[])

--- a/zlang.inc
+++ b/zlang.inc
@@ -4,20 +4,24 @@
 	Author: ziggi
 
 */
+
 #if !defined _samp_included
 	#error Please include a_samp or a_npc before zlang
 #endif
 
-#if !defined SetGVarString
-	#tryinclude "gvar"
-#endif
+// GVar
+#if !defined ZLANG_DISABLE_GVAR
+	#if !defined SetGVarString
+		#tryinclude "gvar"
+	#endif
 
-#if !defined SetGVarString
-	#tryinclude <gvar>
-#endif
+	#if !defined SetGVarString
+		#tryinclude <gvar>
+	#endif
 
-#if !defined SetGVarString
-	#error Please include gvar before zlang
+	#if !defined SetGVarString
+		#error Please include gvar before zlang
+	#endif
 #endif
 
 #if defined _zlang_included
@@ -80,6 +84,12 @@
 
 #if !defined MAX_LANG_FILENAME
 	#define MAX_LANG_FILENAME (256)
+#endif
+
+#if defined ZLANG_DISABLE_GVAR
+	#if !defined MAX_LANG_SVAR_NAME
+		#define MAX_LANG_SVAR_NAME (MAX_LANGS + MAX_LANG_VAR_STRING)
+	#endif
 #endif
 
 #define INVALID_LANG_ID (Lang:-1)
@@ -280,7 +290,11 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 		idx,
 		symbol,
 		length,
+	#if !defined ZLANG_DISABLE_GVAR
 		strings_with_vars;
+	#else
+		bool:isProcessSvar = false;
+	#endif
 
 	while (fread(flang, string, sizeof(string))) {
 		switch (string[0]) {
@@ -383,6 +397,7 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 					strdel(string, i + 1, i + length + 1);
 				}
 				case 'v': {
+				#if !defined ZLANG_DISABLE_GVAR
 					new
 						exist,
 						temp[MAX_LANG_VAR_STRING + 1];
@@ -393,16 +408,28 @@ stock Lang_LoadFile(Lang:lang, const filename[])
 						SetGVarString("zlang_vars_name", varname, strings_with_vars);
 						strings_with_vars++;
 					}
+				#else
+					isProcessSvar = true;
+				#endif
 				}
 			}
 		}
 
 		string[i] = '\0';
 		_Lang_SetText(lang, varname, string[sep_epos]);
+
+	#if defined ZLANG_DISABLE_GVAR
+		if (isProcessSvar) {
+			isProcessSvar = false;
+			_Lang_ProcessSVars(lang, varname);
+		}
+	#endif
 	}
 
+#if !defined ZLANG_DISABLE_GVAR
 	// vars processing
-	_Lang_ProcessVars(lang, strings_with_vars);
+	_Lang_ProcessGVars(lang, strings_with_vars);
+#endif
 
 	fclose(flang);
 	return fid;
@@ -660,8 +687,12 @@ stock Lang_SetText(Lang:lang, const var[], const text[])
 	new res = _Lang_SetText(lang, var_temp, text);
 
 	if (strfind(text, "\\v(", true) != -1) {
+	#if !defined ZLANG_DISABLE_GVAR
 		SetGVarString("zlang_vars_name", var, 0);
-		_Lang_ProcessVars(lang, 1);
+		_Lang_ProcessGVars(lang, 1);
+	#else
+		_Lang_ProcessSVars(lang, var_temp);
+	#endif
 	}
 
 	return res;
@@ -1047,6 +1078,15 @@ stock Lang_UpdatePlayer3DTextLabel(playerid, PlayerText3D:id, color, const var[]
 	Private functions
 */
 
+#if defined ZLANG_DISABLE_GVAR
+
+static stock _Lang_GetSVar(Lang:lang, const var[], svarname[], const size = sizeof(svarname))
+{
+	format(svarname, size, "%d%s", _:lang, var);
+}
+
+#endif
+
 static stock _Lang_FindFile(Lang:lang, const filename[])
 {
 	for (new fid = 0; fid < MAX_LANG_FILES; fid++) {
@@ -1079,7 +1119,15 @@ static stock _Lang_GetFreeFileSlot(Lang:lang)
 
 static stock _Lang_SetText(Lang:lang, const var[], const text[])
 {
+#if !defined ZLANG_DISABLE_GVAR
 	return SetGVarString(var, text, LANG_VAR_OFFSET + _:lang);
+#else
+	static
+		svarname[MAX_LANG_SVAR_NAME + 1];
+
+	_Lang_GetSVar(lang, var, svarname);
+	return SetSVarString(svarname, text);
+#endif
 }
 
 static stock _Lang_GetText(Lang:lang, const var[], text[], const size = sizeof(text))
@@ -1088,15 +1136,31 @@ static stock _Lang_GetText(Lang:lang, const var[], text[], const size = sizeof(t
 		success,
 		i,
 		text_multi[MAX_LANG_VALUE_STRING],
+	#if !defined ZLANG_DISABLE_GVAR
 		var_multi[MAX_LANG_VAR_STRING + 6];
+	#else
+		var_multi[MAX_LANG_SVAR_NAME + 6],
+		svarname[MAX_LANG_SVAR_NAME + 1];
+	#endif
 
+#if !defined ZLANG_DISABLE_GVAR
 	success = GetGVarString(var, text, size, LANG_VAR_OFFSET + _:lang);
+#else
+	_Lang_GetSVar(lang, var, svarname);
+	success = GetSVarString(svarname, text, size);
+#endif
+
 	if (!success) {
 		i = 0;
 
 		do {
+		#if !defined ZLANG_DISABLE_GVAR
 			format(var_multi, sizeof(var_multi), "%s_%d", var, i);
 			success = GetGVarString(var_multi, text_multi, sizeof(text_multi), LANG_VAR_OFFSET + _:lang);
+		#else
+			format(var_multi, sizeof(var_multi), "%s_%d", svarname, i);
+			success = GetSVarString(var_multi, text_multi, sizeof(text_multi));
+		#endif
 
 			if (success) {
 				if (i == 0) {
@@ -1117,15 +1181,33 @@ static stock _Lang_GetText(Lang:lang, const var[], text[], const size = sizeof(t
 
 static stock _Lang_RemoveText(Lang:lang, const var[])
 {
+#if !defined ZLANG_DISABLE_GVAR
 	return DeleteGVar(var, LANG_VAR_OFFSET + _:lang);
+#else
+	static
+		svarname[MAX_LANG_SVAR_NAME + 1];
+
+	_Lang_GetSVar(lang, var, svarname);
+	return DeleteSVar(svarname);
+#endif
 }
 
 static stock _Lang_IsTextExists(Lang:lang, const var[])
 {
+#if !defined ZLANG_DISABLE_GVAR
 	return GetGVarType(var, LANG_VAR_OFFSET + _:lang) != GLOBAL_VARTYPE_NONE;
+#else
+	static
+		svarname[MAX_LANG_SVAR_NAME + 1];
+
+	_Lang_GetSVar(lang, var, svarname);
+	return GetSVarType(svarname) != SERVER_VARTYPE_NONE;
+#endif
 }
 
-static stock _Lang_ProcessVars(Lang:lang, strings_with_vars)
+#if !defined ZLANG_DISABLE_GVAR
+
+static stock _Lang_ProcessGVars(Lang:lang, strings_with_vars)
 {
 	new
 		i,
@@ -1178,6 +1260,45 @@ static stock _Lang_ProcessVars(Lang:lang, strings_with_vars)
 		}
 	} while (next_iteration);
 }
+
+#else
+
+static stock _Lang_ProcessSVars(Lang:lang, const var[])
+{
+	new
+		spos,
+		epos,
+		varvalue[MAX_LANG_VALUE_STRING + 1],
+		vartmp[MAX_LANG_SVAR_NAME + 1],
+		valtmp[MAX_LANG_VALUE_STRING + 1];
+
+	_Lang_GetText(lang, var, varvalue);
+
+	while ((spos = strfind(varvalue, "\\v(", true, spos)) != -1) {
+		epos = strfind(varvalue, ")", true, spos);
+		if (epos == -1) {
+			printf("Error: error with using language variables, example of usage: \\v(VARIABLE)");
+			return;
+		}
+
+		strmid(vartmp, varvalue, spos + 3, epos);
+
+		if (vartmp[0] == '%' && vartmp[1] == 's') {
+			spos += 1;
+			_Lang_SetText(lang, var, varvalue);
+			return;
+		}
+
+		_Lang_GetText(lang, vartmp, valtmp);
+
+		strdel(varvalue, spos, epos + 1);
+		format(varvalue, sizeof(varvalue), "%.*s%s%s", spos, varvalue, valtmp, varvalue[spos]);
+
+		_Lang_SetText(lang, var, varvalue);
+	}
+}
+
+#endif
 
 stock Lang_ProcessDynamicVars(Lang:lang, text[], const size = sizeof(text))
 {

--- a/zlang.inc
+++ b/zlang.inc
@@ -1112,21 +1112,6 @@ static stock _Lang_DeleteVar(Lang:lang, const var[])
 #endif
 }
 
-static stock _Lang_GetVarType(Lang:lang, const var[])
-{
-#if defined LANG_USE_GVAR
-	return GetGVarType(var, LANG_VAR_OFFSET + _:lang) != GLOBAL_VARTYPE_NONE;
-#endif
-
-#if defined LANG_USE_SVAR
-	static
-		varname[MAX_LANG_PREFIX_SVAR_STRING + 1];
-
-	_Lang_ConvertVar(lang, var, varname);
-	return GetSVarType(varname) != SERVER_VARTYPE_NONE;
-#endif
-}
-
 /*
 	SVar functions
 */
@@ -1220,7 +1205,17 @@ static stock _Lang_RemoveText(Lang:lang, const var[])
 
 static stock _Lang_IsTextExists(Lang:lang, const var[])
 {
-	return _Lang_GetVarType(lang, var);
+#if defined LANG_USE_GVAR
+	return GetGVarType(var, LANG_VAR_OFFSET + _:lang) != GLOBAL_VARTYPE_NONE;
+#endif
+
+#if defined LANG_USE_SVAR
+	static
+		varname[MAX_LANG_PREFIX_SVAR_STRING + 1];
+
+	_Lang_ConvertVar(lang, var, varname);
+	return GetSVarType(varname) != SERVER_VARTYPE_NONE;
+#endif
 }
 
 static stock _Lang_ProcessVars(Lang:lang, const var[])

--- a/zlang.inc
+++ b/zlang.inc
@@ -14,7 +14,11 @@
 
 // Method of using variables
 #if !defined LANG_USE_SVAR && !defined LANG_USE_GVAR
-  #define LANG_USE_GVAR
+	#define LANG_USE_GVAR
+#endif
+
+#if defined LANG_USE_SVAR && defined LANG_USE_GVAR
+	#error You cannot use LANG_USE_SVAR and LANG_USE_GVAR at the same time
 #endif
 
 // Include GVar
@@ -1123,17 +1127,18 @@ static stock _Lang_GetVarType(Lang:lang, const var[])
 #endif
 }
 
-static stock _Lang_ConvertVar(Lang:lang, const var[], varname[], const size = sizeof(varname))
-{
-#if defined LANG_USE_GVAR
-	#pragma unused lang
-	_Lang_strcpy(varname, var, size);
-#endif
+/*
+	SVar functions
+*/
 
 #if defined LANG_USE_SVAR
+
+static stock _Lang_ConvertVar(Lang:lang, const var[], varname[], const size = sizeof(varname))
+{
 	format(varname, size, LANG_SVAR_VARNAME_MASK, _:lang, var);
-#endif
 }
+
+#endif
 
 /*
 	Private functions


### PR DESCRIPTION
Добавил возможность не использовать GVar плагин, написал в README, что только при наличии omp можно его не использовать. Некоторые просто не хотят его ставить только ради zlang. В omp появилась такая возможность.

SVar's в omp стали на уровне GVar's:
- Большой лимит имени
- Неограниченное количество
- Скорость

Вроде как всё учёл и протестировал - работает.