### PR TITLE
Optimization function Lang_SendTextToAll, Lang_SendTextToPlayers, Lang_GameTextForAll

### DIFF
--- a/zlang.inc
+++ b/zlang.inc
@@ -891,7 +891,20 @@ stock Lang_SendTextToAll(const var[], lang_args<>)
 	static
 		playerid,
 		Lang:lang,
-		text[MAX_LANG_FORMAT_STRING];
+		text[Lang:MAX_LANGS][MAX_LANG_FORMAT_STRING + 1];
+
+	for (lang = Lang:0; lang < Lang:MAX_LANGS; lang++) {
+		if (_Lang_GetSlotStatus(lang) == LANG_SLOT_FREE) {
+			continue;
+		}
+
+		Lang_GetText(lang, var, text[lang]);
+		Lang_format(text[lang], sizeof(text[]), text[lang], lang_start<1>);
+
+#if defined ENABLE_LANG_DYNAMIC_VARS
+		Lang_ProcessDynamicVars(lang, text[lang]);
+#endif
+	}
 
 #if defined foreach
 	foreach (playerid : Player) {
@@ -901,38 +914,33 @@ stock Lang_SendTextToAll(const var[], lang_args<>)
 			continue;
 		}
 #endif
-		lang = Lang_GetPlayerLang(playerid);
-
-		Lang_GetText(lang, var, text);
-		Lang_format(text, sizeof(text), text, lang_start<1>);
-#if defined ENABLE_LANG_DYNAMIC_VARS
-		Lang_ProcessDynamicVars(lang, text);
-#endif
-
-		SendClientMessage(playerid, -1, text);
+		SendClientMessage(playerid, -1, text[Lang_GetPlayerLang(playerid)]);
 	}
-	return 1;
 }
 
-stock Lang_SendTextToPlayers(const players[], const var[], lang_args<>)
+stock Lang_SendTextToPlayers(const players[], const size = sizeof(players), const var[], lang_args<>)
 {
 	static
 		idx,
 		Lang:lang,
-		text[MAX_LANG_FORMAT_STRING];
+		text[Lang:MAX_LANGS][MAX_LANG_FORMAT_STRING + 1];
 
-	for (idx = 0; players[idx] != INVALID_PLAYER_ID; idx++) {
-		lang = Lang_GetPlayerLang(players[idx]);
+	for (lang = Lang:0; lang < Lang:MAX_LANGS; lang++) {
+		if (_Lang_GetSlotStatus(lang) == LANG_SLOT_FREE) {
+			continue;
+		}
 
-		Lang_GetText(lang, var, text);
-		Lang_format(text, sizeof(text), text, lang_start<2>);
+		Lang_GetText(Lang:lang, var, text[lang]);
+		Lang_format(text[lang], sizeof(text[]), text[lang], lang_start<3>);
+
 #if defined ENABLE_LANG_DYNAMIC_VARS
-		Lang_ProcessDynamicVars(lang, text);
+		Lang_ProcessDynamicVars(lang, text[lang]);
 #endif
-
-		SendClientMessage(players[idx], -1, text);
 	}
-	return 1;
+
+	for (idx = 0; idx < size && players[idx] != INVALID_PLAYER_ID; idx++) {
+		SendClientMessage(players[idx], -1, text[Lang_GetPlayerLang(players[idx])]);
+	}
 }
 
 stock Lang_ShowDialog(playerid, dialogid, style, const var_caption[], const var_info[], const var_button1[], const var_button2[], lang_args<>)
@@ -982,7 +990,20 @@ stock Lang_GameTextForAll(time, style, const var[], lang_args<>)
 	static
 		playerid,
 		Lang:lang,
-		text[MAX_LANG_FORMAT_STRING];
+		text[Lang:MAX_LANGS][MAX_LANG_FORMAT_STRING + 1];
+
+	for (lang = Lang:0; lang < Lang:MAX_LANGS; lang++) {
+		if (_Lang_GetSlotStatus(lang) == LANG_SLOT_FREE) {
+			continue;
+		}
+
+		Lang_GetText(Lang:lang, var, text[lang]);
+		Lang_format(text[lang], sizeof(text[]), text[lang], lang_start<3>);
+
+#if defined ENABLE_LANG_DYNAMIC_VARS
+		Lang_ProcessDynamicVars(lang, text[lang]);
+#endif
+	}
 
 #if defined foreach
 	foreach (playerid : Player) {
@@ -992,18 +1013,8 @@ stock Lang_GameTextForAll(time, style, const var[], lang_args<>)
 			continue;
 		}
 #endif
-		lang = Lang_GetPlayerLang(playerid);
-
-		Lang_GetText(lang, var, text);
-		Lang_format(text, sizeof(text), text, lang_start<3>);
-#if defined ENABLE_LANG_DYNAMIC_VARS
-		Lang_ProcessDynamicVars(lang, text);
-#endif
-
-		GameTextForPlayer(playerid, text, time, style);
+		GameTextForPlayer(playerid, text[Lang_GetPlayerLang(playerid)], time, style);
 	}
-
-	return GameTextForAll(text, time, style);
 }
 
 stock PlayerText:Lang_CreatePlayerTextDraw(playerid, Float:x, Float:y, const var[], lang_args<>)

--- a/zlang.inc
+++ b/zlang.inc
@@ -930,7 +930,7 @@ stock Lang_SendTextToPlayers(const players[], const size = sizeof(players), cons
 			continue;
 		}
 
-		Lang_GetText(Lang:lang, var, text[lang]);
+		Lang_GetText(lang, var, text[lang]);
 		Lang_format(text[lang], sizeof(text[]), text[lang], lang_start<3>);
 
 #if defined ENABLE_LANG_DYNAMIC_VARS
@@ -997,7 +997,7 @@ stock Lang_GameTextForAll(time, style, const var[], lang_args<>)
 			continue;
 		}
 
-		Lang_GetText(Lang:lang, var, text[lang]);
+		Lang_GetText(lang, var, text[lang]);
 		Lang_format(text[lang], sizeof(text[]), text[lang], lang_start<3>);
 
 #if defined ENABLE_LANG_DYNAMIC_VARS

--- a/zlang.inc
+++ b/zlang.inc
@@ -894,7 +894,7 @@ stock Lang_SendTextToAll(const var[], lang_args<>)
 		text[Lang:MAX_LANGS][MAX_LANG_FORMAT_STRING + 1];
 
 	for (lang = Lang:0; lang < Lang:MAX_LANGS; lang++) {
-		if (_Lang_GetSlotStatus(lang) == LANG_SLOT_FREE) {
+		if (!Lang_IsValid(lang)) {
 			continue;
 		}
 
@@ -918,7 +918,7 @@ stock Lang_SendTextToAll(const var[], lang_args<>)
 	}
 }
 
-stock Lang_SendTextToPlayers(const players[], const size = sizeof(players), const var[], lang_args<>)
+stock Lang_SendTextToPlayers(const players[], const var[], lang_args<>)
 {
 	static
 		idx,
@@ -926,7 +926,32 @@ stock Lang_SendTextToPlayers(const players[], const size = sizeof(players), cons
 		text[Lang:MAX_LANGS][MAX_LANG_FORMAT_STRING + 1];
 
 	for (lang = Lang:0; lang < Lang:MAX_LANGS; lang++) {
-		if (_Lang_GetSlotStatus(lang) == LANG_SLOT_FREE) {
+		if (!Lang_IsValid(lang)) {
+			continue;
+		}
+
+		Lang_GetText(lang, var, text[lang]);
+		Lang_format(text[lang], sizeof(text[]), text[lang], lang_start<2>);
+
+#if defined ENABLE_LANG_DYNAMIC_VARS
+		Lang_ProcessDynamicVars(lang, text[lang]);
+#endif
+	}
+
+	for (idx = 0; players[idx] != INVALID_PLAYER_ID; idx++) {
+		SendClientMessage(players[idx], -1, text[Lang_GetPlayerLang(players[idx])]);
+	}
+}
+
+stock Lang_SendTextToPlayersEx(const players[], const size = sizeof(players), const var[], lang_args<>)
+{
+	static
+		idx,
+		Lang:lang,
+		text[Lang:MAX_LANGS][MAX_LANG_FORMAT_STRING + 1];
+
+	for (lang = Lang:0; lang < Lang:MAX_LANGS; lang++) {
+		if (!Lang_IsValid(lang)) {
 			continue;
 		}
 
@@ -993,7 +1018,7 @@ stock Lang_GameTextForAll(time, style, const var[], lang_args<>)
 		text[Lang:MAX_LANGS][MAX_LANG_FORMAT_STRING + 1];
 
 	for (lang = Lang:0; lang < Lang:MAX_LANGS; lang++) {
-		if (_Lang_GetSlotStatus(lang) == LANG_SLOT_FREE) {
+		if (!Lang_IsValid(lang)) {
 			continue;
 		}
 


### PR DESCRIPTION
Код внутри функций постоянно прокручивает `Lang_GetText`, `Lang_format`, `Lang_ProcessDynamicVars` (опционально) для **каждого** игрока. Будет значительно быстрее, если сначала всё это будет сделано в начале, а игрокам просто итоговый результат показывать. Потому что в чём смысл, если постоянно вызывать эти функции для игроков, например, с русским языком, который будет обрабатываться для **каждого**, если можно один раз.

Самый сок, можно ещё добавить количество используемых языков игроками на сервере. Т.е. игрок заходит на сервер, фиксируем какой язык (или меняет его), потом в циклах этих функций, просто проверяем, используют ли игроки на данный момент данный язык, если нет - `continue`.

Кстати, не понял прикола с `Lang_SendTextToPlayers`, она не работает, добавил аргумент.